### PR TITLE
Java 6 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+.settings
+.project
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,19 @@
 			<version>4.0.0</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<licenses>
 		<license>
 			<name>CC0</name>

--- a/src/main/java/io/github/yonran/jna2pcsc/Smartcardio.java
+++ b/src/main/java/io/github/yonran/jna2pcsc/Smartcardio.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import javax.smartcardio.ATR;
 import javax.smartcardio.Card;
@@ -310,7 +309,9 @@ public class Smartcardio {
 		@Override public Card getCard() {return card;}
 		@Override public int getChannelNumber() {return channel & 0xff;}
 		@Override public ResponseAPDU transmit(CommandAPDU command) throws CardException {
-			Objects.requireNonNull(command, "command");
+			if (command == null) {
+				throw new IllegalArgumentException("command is null");
+			}
 			byte[] commandCopy = command.getBytes();
 			ByteBuffer response = transmitImpl(commandCopy, null);
 
@@ -366,8 +367,12 @@ public class Smartcardio {
 		 * Le is either 00-ff (00=256) or 0000-ffff. (0000=65536)
 		 */
 		@Override public int transmit(ByteBuffer command, ByteBuffer response) throws CardException {
-			Objects.requireNonNull(response, "response");
-			Objects.requireNonNull(command, "command");
+			if (command == null) {
+				throw new IllegalArgumentException("command is null");
+			}
+			if (response == null) {
+				throw new IllegalArgumentException("response is null");
+			}
 			byte[] copy = new byte[command.remaining()];
 			command.get(copy);
 			command = ByteBuffer.wrap(copy);


### PR DESCRIPTION
- Ensure Java 6 compatibility by replacing Objects.requireNonNull
  checks with plain null checks, and using 1.6 source/target levels
- Minor: gitignore entries for Eclipse
