### PR TITLE
Fix for SCARD_E_INVALID_PARAMETER on Mac OS X Mavericks and earlier.

### DIFF
--- a/src/main/java/jnasmartcardio/Smartcardio.java
+++ b/src/main/java/jnasmartcardio/Smartcardio.java
@@ -418,11 +418,12 @@ public class Smartcardio extends Provider {
 			switch ((int)err) {
 			case SCARD_S_SUCCESS:
 				Winscard.SCardHandle scardHandle = phCard.getValue();
+				DwordByReference readerLength = new DwordByReference();
 				DwordByReference currentState = new DwordByReference();
 				DwordByReference currentProtocol = new DwordByReference();
 				ByteBuffer atrBuf = ByteBuffer.allocate(Smartcardio.MAX_ATR_SIZE);
 				DwordByReference atrLength = new DwordByReference(new Dword(Smartcardio.MAX_ATR_SIZE));
-				check("SCardStatus", libInfo.lib.SCardStatus(scardHandle, null, null, currentState, currentProtocol, atrBuf, atrLength));
+				check("SCardStatus", libInfo.lib.SCardStatus(scardHandle, null, readerLength, currentState, currentProtocol, atrBuf, atrLength));
 				int atrLengthInt = atrLength.getValue().intValue();
 				atrBuf.limit(atrLengthInt);
 				byte[] atrBytes = new byte[atrBuf.remaining()];


### PR DESCRIPTION
Initially caused by fix for Mac OS X Yosemite. Older implementations (Mavericks and earlier) can't deal with the readerLength being NULL.
