### PR TITLE
Have rough versioning of the provider

### DIFF
--- a/src/main/java/jnasmartcardio/Smartcardio.java
+++ b/src/main/java/jnasmartcardio/Smartcardio.java
@@ -42,7 +42,7 @@ public class Smartcardio extends Provider {
 	public static final String PROVIDER_NAME = "JNA2PCSC";
 	
 	public Smartcardio() {
-		super(PROVIDER_NAME, 0.0d, "JNA-to-PCSC Provider");
+		super(PROVIDER_NAME, 0.2d, "JNA-to-PCSC Provider");
 		put("TerminalFactory.PC/SC", JnaTerminalFactorySpi.class.getName());
 	}
 	


### PR DESCRIPTION
Having a version looks better when printing out the provider information for debugging purposes:
```
$ sc -ldv -jna
# Using jnasmartcardio.Smartcardio - JNA2PCSC version 0.0
No readers: SCARD_E_NO_SERVICE
```