### PR TITLE
Do not pass null, which would get dereferenced in the for loop

### DIFF
--- a/src/main/java/jnasmartcardio/Smartcardio.java
+++ b/src/main/java/jnasmartcardio/Smartcardio.java
@@ -110,7 +110,7 @@ public class Smartcardio extends Provider {
 		public JnaCardTerminals(Winscard.WinscardLibInfo libInfo, Winscard.SCardContext scardContext) {
 			this.libInfo = libInfo;
 			this.scardContext = scardContext;
-			this.knownReaders = createScardReaderStates(Collections.<String>emptyList(), usePnp, (SCardReaderState[])null);
+			this.knownReaders = createScardReaderStates(Collections.<String>emptyList(), usePnp, new SCardReaderState[0]);
 			this.zombieReaders = new ArrayList<SCardReaderState>();
 		}
 


### PR DESCRIPTION
As found by Coverity.
