### PR TITLE
Explicit jna library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>
 			<artifactId>jna</artifactId>
-			<version>[3.2.5,4.0.0]</version>
+			<version>4.0.0</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
JNA library version in Maven metadata was updated so the project doesn't compile anymore with an error: 

`Could not find any version that matches net.java.dev.jna:jna:[3.2.5,4.0.0]`

Also, this, in turn, prevents the build of any project that uses `jnasmartcardio`. 

This PR explicitly specifies the version of the `jna` library to `4.0.0`. 