### PR TITLE
Make it compile with JNA version 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>
 			<artifactId>jna</artifactId>
-			<version>4.0.0</version>
+			<version>5.4.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/jnasmartcardio/Winscard.java
+++ b/src/main/java/jnasmartcardio/Winscard.java
@@ -80,7 +80,7 @@ class Winscard {
 	 */
 	public static class Handle extends IntegerType {
 		private static final long serialVersionUID = 1L;
-		public static final int SIZE = Platform.isWindows() ? Pointer.SIZE : Dword.SIZE;
+		public static final int SIZE = Platform.isWindows() ? Native.POINTER_SIZE : Dword.SIZE;
 		public Handle(long value) {
 			super(SIZE, value);
 		}


### PR DESCRIPTION
As mentioned in #35, compilation fails since JNA version 5 (see https://github.com/java-native-access/jna/blob/master/CHANGES.md#breaking-changes). This little change makes this library compatible with version 5.