### PR TITLE
feat: add `withUnpowerOnDisconnect()` to Smartcardio

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+jnasmartcardio-0.3.0 (2025-03-05)
+===
+* Add `Smartcardio.withUnpowerOnDisconnect()` to handle B Prime card with ParagonId readers.
+
 jnasmartcardio-0.2.7 (2015-12-05)
 ===
 * [#31](https://github.com/jnasmartcardio/jnasmartcardio/pull/31) Depend on JNA 4.0.0 explicitly since the dependency range [3.2.5, 4.0.0] stopped working. The user can override JNA to anything between 3.2.5 and the latest 4.3.0.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>io.github.jnasmartcardio</groupId>
 	<artifactId>jnasmartcardio</artifactId>
-	<version>0.2.8-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>jnasmartcardio</name>
@@ -34,8 +34,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/jnasmartcardio/Smartcardio.java
+++ b/src/main/java/jnasmartcardio/Smartcardio.java
@@ -955,7 +955,7 @@ public class Smartcardio extends Provider {
 	 * from libj2pcsc on OS X java7.
 	 * @param  
 	 */
-	private static List<String> 	pcsc_multi2jstring(byte[] multiString, Charset charset) {
+	private static List<String> pcsc_multi2jstring(byte[] multiString, Charset charset) {
 		List<String> r = new ArrayList<String>();
 		int from = 0, to = 0;
 		for (; to < multiString.length; to++) {

--- a/src/main/java/jnasmartcardio/Smartcardio.java
+++ b/src/main/java/jnasmartcardio/Smartcardio.java
@@ -38,10 +38,37 @@ public class Smartcardio extends Provider {
 	static final int MAX_ATR_SIZE = 33;
 
 	public static final String PROVIDER_NAME = "JNA2PCSC";
-	
+	private static boolean useUnpowerOnDisconnect;
+
 	public Smartcardio() {
 		super(PROVIDER_NAME, 0.2d, "JNA-to-PCSC Provider");
 		put("TerminalFactory.PC/SC", JnaTerminalFactorySpi.class.getName());
+	}
+
+	/**
+	 * Configures the smart card to be powered off during disconnection.
+	 *
+	 * <p>When this option is enabled, the {@link JnaCard#disconnect(boolean)} method will use
+	 * the SCARD_UNPOWER_CARD option instead of SCARD_RESET_CARD when disconnecting
+	 * with reset.
+	 *
+	 * <p>Powering off the card (SCARD_UNPOWER_CARD) causes a complete shutdown of the
+	 * card's power supply, which is more radical than a simple reset (SCARD_RESET_CARD).
+	 *
+	 * <p>It is advisable to use this option in certain cases where card presence detection is 
+	 * not handled correctly by the reader (particularly with Innovatron's B Prime contactless 
+	 * protocol requiring a APDU-based polling to check the card presence waiting for the removal).
+	 *
+	 * @return the current instance to allow method chaining
+	 * @since 0.3.0
+	 */
+	public Smartcardio withUnpowerOnDisconnect() {
+		useUnpowerOnDisconnect = true; // NOSONAR
+		return this;
+	}
+
+	static int getDisconnectModeForReset() {
+		return useUnpowerOnDisconnect ? JnaCard.SCARD_UNPOWER_CARD : JnaCard.SCARD_RESET_CARD;
 	}
 	
 	public static class JnaTerminalFactorySpi extends TerminalFactorySpi {
@@ -558,7 +585,7 @@ public class Smartcardio extends Provider {
 		}
 
 		@Override public void disconnect(boolean reset) throws CardException {
-			int dwDisposition = reset ? SCARD_RESET_CARD : SCARD_LEAVE_CARD;
+			int dwDisposition = reset ? Smartcardio.getDisconnectModeForReset() : SCARD_LEAVE_CARD;
 			check("SCardDisconnect", libInfo.lib.SCardDisconnect(scardHandle, new Dword(dwDisposition)));
 		}
 
@@ -928,7 +955,7 @@ public class Smartcardio extends Provider {
 	 * from libj2pcsc on OS X java7.
 	 * @param  
 	 */
-	private static List<String> pcsc_multi2jstring(byte[] multiString, Charset charset) {
+	private static List<String> 	pcsc_multi2jstring(byte[] multiString, Charset charset) {
 		List<String> r = new ArrayList<String>();
 		int from = 0, to = 0;
 		for (; to < multiString.length; to++) {


### PR DESCRIPTION
Introduce a new configuration method to power off smart cards on disconnection instead of resetting, addressing specific reader compatibility issues. Updated version to 0.3.0 and Java compatibility to 1.8 to support these changes.